### PR TITLE
Change back

### DIFF
--- a/suppliers/security-expectations.md
+++ b/suppliers/security-expectations.md
@@ -56,7 +56,7 @@ The following basic technical requirements are considered mandatory, unless othe
 - All actions on data, such as viewing, editing and deleting, must be logged and audited at the individual user level
 - penetration tests and IT Health Checks *must* be performed *and* satisfactorily passed *before* a service goes live. The tests and checks *must* also be run again, *and* satisfactorily passed:
    - at intervals of not more than 12 calendar months since the last successful tests
-   - after any major change to infrastructure goes live, including but not limited to modifications to functional capability, implementation, or hosting
+   - before any major change to infrastructure goes live, including but not limited to modifications to functional capability, implementation, or hosting
 - any issues identified during Penetration tests or IT Health Check as a result of service changes *must* be mitigated or accepted before the service changes go live
 - user submitted data *must* be validated to prevent web threats such as injection attacks and cross site scripting
 - an 'idle' timeout *must* be enforced, to detect and close inactive sessions


### PR DESCRIPTION
Changed:
"after any major change to infrastructure goes live"
with:
"before any major change to infrastructure goes live"
as we want to do any pen tests after a major change is made BUT before it goes live.